### PR TITLE
Removed call to clear storage on page refresh

### DIFF
--- a/Develop/script.js
+++ b/Develop/script.js
@@ -56,7 +56,6 @@ searchBtn.addEventListener("click", async function () {
   renderSearch()
   getPlaylists();
 });
-localStorage.clear();
 
 //saving searched cities
 function renderSearch(){


### PR DESCRIPTION
Removed a call to clear the local storage when the page first loads which breaks the persistent data storage.