### PR TITLE
Removed cancel button showing on first load. Resolved class/id issue on close buttons.

### DIFF
--- a/Develop/script.js
+++ b/Develop/script.js
@@ -10,12 +10,13 @@ var currentTemp = document.querySelector("#temperature");
 var currentCity = document.querySelector("#city-name");
 var weather = document.querySelector("#weather-description");
 var currentWeather; //Initialized in displayWeather for use in getPlaylists()
-var weatherModal = document.querySelector("#myModal")
-weatherModal.style.display = "block"
-var changeCityBtn = document.querySelector("#change-city")
-var closeBtn = document.querySelector(".close")
+var weatherModal = document.querySelector("#myModal");
+weatherModal.style.display = "block";
+var changeCityBtn = document.querySelector("#change-city");
+var closeInputBtn = document.querySelector("#close-input");
+closeInputBtn.style.display = "none";
 var previewModal = document.querySelector("#preview-modal");
-var previewCloseBtn = document.querySelector("#close-preview");
+var previewCloseBtn = document.querySelector("#preview-button");
 previewCloseBtn.style.display = "none";
 //fardina's code
 
@@ -60,7 +61,7 @@ function displayWeather(city) {
 }
   
   //event listener for closing modal on x
-  closeBtn.addEventListener("click", function () {
+  closeInputBtn.addEventListener("click", function () {
     weatherModal.style.display = "none";
   });
     
@@ -72,9 +73,7 @@ function displayWeather(city) {
     var searchValue = input.value
     displayWeather(searchValue);
   });
-  
-  //localStorage.clear()
-  
+
   //saving searched cities
   function renderSearch(){
     let savedCities = JSON.parse(localStorage.getItem("city")) || [];
@@ -92,15 +91,23 @@ function displayWeather(city) {
     //event listener to open modal once change city button is selected
     changeCityBtn.addEventListener("click", function () {
       weatherModal.style.display = "block";
+      closeInputBtn.style.display = "block";
     });
   }
 
 
 //jackson's code 
-var key = "AIzaSyBDMCgP5fKCMZ7RcyVVZL0XPJuQuuNZqLQ" //Jackson's key
+//var key = "AIzaSyBDMCgP5fKCMZ7RcyVVZL0XPJuQuuNZqLQ" //Jackson's key
 //var key = "AIzaSyCTPCZ0BW1oVO9rOTLhWPKmaxI45OKeyvA" //Hamzah's Key
+var key = "AIzaSyBSZpk2XNTzLPpNRXXODZZ7BxzVoCgkBrs" //Spare Key
 
 function getPlaylists() {
+  //Clear any cached playlist previews
+  if (previewModal.children.length > 1) {
+    for (var i=1; i<previewModal.children.length; i++) {
+      previewModal.removeChild(previewModal.children[i]);
+    }
+  }
   var genre = document.querySelector("#genre-dropdown").value;
   switch (currentWeather) {
     case "Rain":
@@ -168,7 +175,7 @@ $(playlist).on("click", ".preview-button", function (event) {
   getPlaylistItems(event.target.dataset.playlistid);
 });
 
-$("#preview-modal").on("click", "#close-preview", function() {
+$("#preview-modal").on("click", ".close", function() {
   previewCloseBtn.style.display = "none";
   $(".modal-content").remove();
  })
@@ -186,13 +193,18 @@ function getPlaylistItems(playlistId) {
 }
 
 //Display each song of a given playlist within a collapsible div
-function showPlaylistItems(playlistData, playlistid) { 
+function showPlaylistItems(playlistData, playlistid) {  
   previewCloseBtn.style.display = "block";
+  //Clear any cached playlist previews
+  if (previewModal.children.length > 1) {
+    for (var i=1; i<previewModal.children.length; i++) {
+      previewModal.removeChild(previewModal.children[i]);
+    }
+  }
   for (var i=0; i<Object.keys(playlistData.items).length; i++) {
     if (playlistData.items[i].snippet.title == "Deleted video") {
       continue;
     }
-    console.log(playlistData.items[i]);
     var previewContentEl = document.createElement("div");
     previewContentEl.setAttribute("class", "modal-content");
     previewContentEl.innerHTML = 

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
           <div class="row">
             <div class="column">
               <div class="lft-column">
-                <span class="close">&times;</span>
+                <span class="close" id="close-input">&times;</span>
                 <div id="location-search">
                   <h2>What city are you in?</h2>
                   <p id="input-error"></p>
@@ -107,7 +107,7 @@
     <!-- Preview Modal -->
     <div id="preview-modal" class="modal">
       <!-- Modal content -->
-      <span id="close-preview">&times;</span>
+      <span class="close" id="preview-button">&times;</span>
     </div>
     <!-- Change City -->
     <button id="change-city">Change City</button>


### PR DESCRIPTION
Hid the cancel modal button in the input modal to prevent the user from moving forward until they have selected a valid city. The cancel button appears once the user has selected to change city in case they choose to cancel and keep current playlists. Assigned id: "close-input" and id: "close-preview" to each of the close buttons so their displays could be altered separately while maintaining their "close" class.