### PR TITLE
Fixed missing class name on preview-button

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
 
     <!-- Preview Modal -->
     <div id="preview-modal" class="modal1">
-      <span id="preview-button">&times;</span>
+      <span id="preview-button" class="close">&times;</span>
     </div>
 
     <!-- Change City -->


### PR DESCRIPTION
Preview modal wouldn't close due to missing class="close" on the close button